### PR TITLE
apply workaround to make the game run on macOS

### DIFF
--- a/desktop/build.gradle.kts
+++ b/desktop/build.gradle.kts
@@ -38,6 +38,9 @@ tasks.register<JavaExec>("run") {
     standardInput = System.`in`
     workingDir = assetsDir
     isIgnoreExitValue = true
+
+    // Fix for macOS
+    jvmArgs = listOf("-XstartOnFirstThread")
 }
 
 tasks.register<JavaExec>("debug") {


### PR DESCRIPTION
The error was:

mac m1 Exception in thread "main" java.lang.IllegalStateException: GLFW may only be used on the main thread and that thread must be the first thread in the process.